### PR TITLE
input_ffmpeg: allocate sample buffer dynamically

### DIFF
--- a/scanner/inputaudio/ffmpeg/input_ffmpeg.c
+++ b/scanner/inputaudio/ffmpeg/input_ffmpeg.c
@@ -28,7 +28,8 @@ struct input_handle {
   int flushing;
   int got_frame;
   int packet_left;
-  float buffer[BUFFER_SIZE / 2 + 1];
+  float *buffer;
+  unsigned buffer_size;
 };
 
 static unsigned ffmpeg_get_channels(struct input_handle* ih) {
@@ -45,7 +46,7 @@ static float* ffmpeg_get_buffer(struct input_handle* ih) {
 
 static struct input_handle* ffmpeg_handle_init() {
   struct input_handle* ret;
-  ret = malloc(sizeof(struct input_handle));
+  ret = calloc(1, sizeof(struct input_handle));
 
   return ret;
 }
@@ -269,9 +270,15 @@ write_to_buffer: ;
   int channels = ih->codec_context->channels;
   // channels = ih->frame->channels;
 
-  if (ih->frame->nb_samples * channels > sizeof ih->buffer) {
-    fprintf(stderr, "buffer too small!\n");
-    return 0;
+  int data_size = nr_frames_read * channels;
+  if (ih->buffer_size < data_size) {
+    float *b = realloc(ih->buffer, data_size * sizeof(float));
+    if (!b) {
+      perror("realloc() failed");
+      return 0;
+    }
+    ih->buffer = b;
+    ih->buffer_size = data_size;
   }
 
   int i;
@@ -350,8 +357,11 @@ static size_t ffmpeg_read_frames(struct input_handle* ih) {
 }
 
 static void ffmpeg_free_buffer(struct input_handle* ih) {
-  (void) ih;
-  return;
+  if (ih->buffer) {
+    free(ih->buffer);
+    ih->buffer = 0;
+    ih->buffer_size = 0;
+  }
 }
 
 static void ffmpeg_close_file(struct input_handle* ih) {

--- a/scanner/scanner-common/scanner-common.c
+++ b/scanner/scanner-common/scanner-common.c
@@ -150,7 +150,6 @@ void init_state_and_scan_work_item(struct filename_list_node *fln, struct scan_o
 
     result = ops->allocate_buffer(ih);
     if (result) abort();
-    buffer = ops->get_buffer(ih);
 
 #ifdef USE_SNDFILE
     if (opts->decode_file) {
@@ -173,6 +172,7 @@ void init_state_and_scan_work_item(struct filename_list_node *fln, struct scan_o
         g_cond_broadcast(progress_cond);
         g_mutex_unlock(progress_mutex);
         fd->number_of_elapsed_frames += nr_frames_read;
+        buffer = ops->get_buffer(ih);
         result = ebur128_add_frames_float(fd->st, buffer, nr_frames_read);
 #ifdef USE_SNDFILE
         if (opts->decode_file) {


### PR DESCRIPTION
also move call to get_buffer() after read_frames() in order to allow
reallocation of the frame buffer
