### PR TITLE
set stdout/stderr to be unbuffered when they are not connected to a file

### DIFF
--- a/scanner/scanner.c
+++ b/scanner/scanner.c
@@ -1,7 +1,12 @@
 /* See COPYING file for copyright and license details. */
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #ifdef G_OS_WIN32
 #include <windows.h>
+#include <io.h>
+#else
+#include <unistd.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -119,6 +124,13 @@ enum modes
     LOUDNESS_MODE_DUMP
 };
 
+void set_buffering_mode(FILE *fp)
+{
+    struct stat stb;
+    if (fstat(fileno(fp), &stb) == 0 && (stb.st_mode & S_IFMT) != S_IFREG)
+        setbuf(fp, 0);
+}
+
 int main(int argc, char *argv[])
 {
     GSList *errors = NULL, *files = NULL;
@@ -129,6 +141,9 @@ int main(int argc, char *argv[])
         print_help();
         exit(EXIT_FAILURE);
     }
+    set_buffering_mode(stdout);
+    set_buffering_mode(stderr);
+
     if (!strcmp(argv[1], "scan")) {
         mode = LOUDNESS_MODE_SCAN;
         mode_parsed = loudness_scan_parse(&argc, &argv);


### PR DESCRIPTION
This fixes somewhat jumbled output due to mixed usage of stdout and
stderr without proper calls to fflush() and letting stdio choose the
default buffering strategy.
On win32, pipes are often used instead pty (since there's no pty on win32),
therefore this issue has higher possibility to appear. For example,
running scanner in psuedo terminal application such as mintty is
enough to reproduce the issue.
unbuffered mode is a simple way to ensure output order to be
always preserved, at the expence of tiny I/O overhead that should be
negligible.
