### PR TITLE
Add w64 file format support

### DIFF
--- a/scanner/inputaudio/ffmpeg/input_ffmpeg.c
+++ b/scanner/inputaudio/ffmpeg/input_ffmpeg.c
@@ -395,4 +395,4 @@ G_MODULE_EXPORT struct input_ops ip_ops = {
 
 G_MODULE_EXPORT const char* ip_exts[] = {
   "wav", "flac", "ogg", "oga", "mp3", "mp2", "mpc", "ac3", "wv", "mpg",
-  "avi", "mkv", "m4a", "mp4", "aac", "mov", "mxf", "opus", NULL};
+  "avi", "mkv", "m4a", "mp4", "aac", "mov", "mxf", "opus", "w64", NULL};

--- a/scanner/inputaudio/sndfile/input_sndfile.c
+++ b/scanner/inputaudio/sndfile/input_sndfile.c
@@ -156,4 +156,4 @@ G_MODULE_EXPORT struct input_ops ip_ops = {
   sndfile_exit_library
 };
 
-G_MODULE_EXPORT const char* ip_exts[] = {"wav", "flac", "ogg", "oga", NULL};
+G_MODULE_EXPORT const char* ip_exts[] = {"wav", "flac", "ogg", "oga", "w64", NULL};


### PR DESCRIPTION
Added w64 file format support to ffmpeg scanner and sndfile scanner.

Useful to use audio files whose size is over 4 GB.