### PR TITLE
Fix: Add missing <cstdint> include

### DIFF
--- a/scanner/scanner-tag/rgtag.cpp
+++ b/scanner/scanner-tag/rgtag.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <ios>


### PR DESCRIPTION
Depending e.g. on compiler version, referring to sized integers could result in compiler error. Add correct std header inclusion for ensuring availability of sized integer type.

Fixes #33 